### PR TITLE
Fix Makefiles to build the correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CURRENT_USER := $(USER)
 leftover=$(shell docker ps -a -q -f status=exited)
 leftover-image=$(shell docker images -a -q)
 username=$(CURRENT_USER)
-image=$(username)/ietf-bgp-yang
+image=$(username)/igp-measurement
 
 all: container
 

--- a/draft/Makefile
+++ b/draft/Makefile
@@ -24,8 +24,7 @@ next_ver ?=
 else
 next_ver ?= $(shell printf "%.2d" $$((1$(current_ver)-99)))
 endif
-#next := $(draft)-$(next_ver)
-next := $(draft)-00
+next := $(draft)-$(next_ver)
 
 .PHONY: default latest clean
 


### PR DESCRIPTION
The issue with the Makefile was that we had hardcoded -00 version in the Makefile. That is why, even though a tag was added, it continued to build it as a -00 version.